### PR TITLE
security: fix zizmor workflow findings

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,21 +19,21 @@ jobs:
       packages: write
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         fetch-depth: 0
 
     - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v1.1.1
+      uses: gittools/actions/gitversion/setup@8d68520cde93ca9226ee0e09870caaca033d2cd2 # v1.1.1
       with:
         versionSpec: '5.x'
 
     - name: Determine Version
       id: gitversion
-      uses: gittools/actions/gitversion/execute@v1.1.1
+      uses: gittools/actions/gitversion/execute@8d68520cde93ca9226ee0e09870caaca033d2cd2 # v1.1.1
 
     - name: Log in to Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -41,7 +41,7 @@ jobs:
 
     - name: Extract metadata
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         tags: |
@@ -51,7 +51,7 @@ jobs:
           type=raw,value=${{ steps.gitversion.outputs.semVer }}
 
     - name: Build and push
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
       with:
         context: .
         push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,11 @@ on:
     branches:
       - master
 
-permissions:
-  contents: write
-
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
## 🔒 zizmor workflow security remediation

This PR auto-fixes security findings detected by [zizmor](https://github.com/woodruffw/zizmor).

### ✅ Fixed

| Rule | File | Line | Description |
|---|---|---|---|
| `zizmor/unpinned-uses` | `.github/workflows/docker.yml` | L22 | unpinned action reference |
| `zizmor/unpinned-uses` | `.github/workflows/docker.yml` | L27 | unpinned action reference |
| `zizmor/unpinned-uses` | `.github/workflows/docker.yml` | L33 | unpinned action reference |
| `zizmor/unpinned-uses` | `.github/workflows/docker.yml` | L36 | unpinned action reference |
| `zizmor/unpinned-uses` | `.github/workflows/docker.yml` | L44 | unpinned action reference |
| `zizmor/unpinned-uses` | `.github/workflows/docker.yml` | L54 | unpinned action reference |
| `zizmor/excessive-permissions` | `.github/workflows/release.yml` | L14 | overly broad permissions |

---

### Fix details

- **excessive-permissions**: Workflow-level permissions moved to individual jobs for least-privilege. New jobs added later won't inherit broad permissions by default.

---
Lucca Security Team